### PR TITLE
fix exception in _writeFontMatter

### DIFF
--- a/src/documenters/MarkdownDocumenter.ts
+++ b/src/documenters/MarkdownDocumenter.ts
@@ -1145,7 +1145,7 @@ export class MarkdownDocumenter {
         let apiMembers: ReadonlyArray<ApiItem> = item.members;
         const mdEmitter = this._markdownEmitter;
 
-        var extractSummary = function (docComment: DocComment): string {
+        var extractSummary = (docComment: DocComment): string => {
             const tmpStrBuilder: StringBuilder = new StringBuilder();
             const summary: DocSection = docComment!.summarySection;
             mdEmitter.emit(tmpStrBuilder, summary, {


### PR DESCRIPTION
make function an arrow function to capture "this", otherwise the call  in L1154 to _getLinkFilenameForApiItem will fail because "this" is undefined